### PR TITLE
スポンサー情報の表示

### DIFF
--- a/components/pages/Top/Sponsor.vue
+++ b/components/pages/Top/Sponsor.vue
@@ -1,18 +1,18 @@
 <template>
-  <section class="p-sponsor">
+  <section class="p-sponsor" v-if="visible">
     <div class="c-container">
       <h3 class="p-sponsor_heading">スポンサー</h3>
-      <div class="p-sponsor_platinum">
+      <div class="p-sponsor_platinum" v-if="sponsors.plutinum && sponsors.plutinum.length">
         <div class="title">
           Platinum
         </div>
         <div class="row">
-          <div class="list col-md-10">
+          <div class="list col-md-10" v-for="sponsor in sponsors.plutinum" :key="sponsor.name">
             <div class="listItem">
               <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
-                <a href="#" class="company">会社名</a>
-                <p class="description">俺は今単にその落第院というのの上をもっななら。何しろ今が関係通りはまあその煩悶うですまでを入れから切らたには記憶なりないですば、いっそにもなっなけれませんた。安危があるたものもとうてい事実をちゃんとでたある。よし嘉納さんでぼんやり詞どう煩悶に応じなら学校その兄弟それかろかをにおいて大記憶たらたたでしょと、この時分はあなたか日数他よりならが、三宅さんのので学校の私にさぞ小評とあるて私教授が小講演に着ようにあたかもご誤解になっないなて、初めてどうしても影響に思いましていなものに当てるなけれた。</p>
+                <a :href="sponsor.url"><div class="thumb" :style="logoStyle(sponsor)" /></a>
+                <a :href="sponsor.url" class="company">{{ sponsor.name }}</a>
+                <p class="description">{{ sponsor.introduction }}</p>
               </div>
               <router-link
                 to="/jobs"
@@ -22,43 +22,17 @@
           </div>
         </div>
       </div>
-      <div class="p-sponsor_gold">
+      <div class="p-sponsor_gold" v-if="sponsors.gold && sponsors.gold.length">
         <div class="title">
           Gold
         </div>
         <div class="row">
-          <div class="list col-sm-6">
+          <div class="list col-sm-6" v-for="sponsor in sponsors.gold" :key="sponsor.name">
             <div class="listItem">
               <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
-                <a href="#" class="company">会社名</a>
-                <p class="description">俺は今単にその落第院というのの上をもっななら。何しろ今が関係通りはまあその煩悶うですまでを入れから切らたには記憶なりないですば、いっそにもなっなけれませんた。安危があるたものもとうてい事実をちゃんとでたある。よし嘉納さんでぼんやり詞どう煩悶に応じなら学校その兄弟それかろかをにおいて大記憶たらたたでしょと、この時分はあなたか日数他よりならが、三宅さんのので学校の私にさぞ小評とあるて私教授が小講演に着ようにあたかもご誤解になっないなて、初めてどうしても影響に思いましていなものに当てるなけれた。</p>
-              </div>
-              <router-link
-                to="/jobs"
-                class="btn">広告・求人ページ<i class="fas fa-chevron-right"></i>
-              </router-link>
-            </div>
-          </div>
-          <div class="list col-sm-6">
-            <div class="listItem">
-              <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
-                <a href="#" class="company">会社名</a>
-                <p class="description">俺は今単にその落第院というのの上をもっななら。何しろ今が関係通りはまあその煩悶うですまでを入れから切らたには記憶なりないですば、いっそにもなっなけれませんた。安危があるたものもとうてい事実をちゃんとでたある。よし嘉納さんでぼんやり詞どう煩悶に応じなら学校その兄弟それかろかをにおいて大記憶たらたたでしょと、この時分はあなたか日数他よりならが、三宅さんのので学校の私にさぞ小評とあるて私教授が小講演に着ようにあたかもご誤解になっないなて、初めてどうしても影響に思いましていなものに当てるなけれた。</p>
-              </div>
-              <router-link
-                to="/jobs"
-                class="btn">広告・求人ページ<i class="fas fa-chevron-right"></i>
-              </router-link>
-            </div>
-          </div>
-          <div class="list col-sm-6">
-            <div class="listItem">
-              <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
-                <a href="#" class="company">会社名</a>
-                <p class="description">俺は今単にその落第院というのの上をもっななら。何しろ今が関係通りはまあその煩悶うですまでを入れから切らたには記憶なりないですば、いっそにもなっなけれませんた。安危があるたものもとうてい事実をちゃんとでたある。よし嘉納さんでぼんやり詞どう煩悶に応じなら学校その兄弟それかろかをにおいて大記憶たらたたでしょと、この時分はあなたか日数他よりならが、三宅さんのので学校の私にさぞ小評とあるて私教授が小講演に着ようにあたかもご誤解になっないなて、初めてどうしても影響に思いましていなものに当てるなけれた。</p>
+                <a :href="sponsor.url"><div class="thumb" :style="logoStyle(sponsor)" /></a>
+                <a :href="sponsor.url" class="company">{{ sponsor.name }}</a>
+                <p class="description">{{ sponsor.introduction }}</p>
               </div>
               <router-link
                 to="/jobs"
@@ -68,48 +42,15 @@
           </div>
         </div>
       </div>
-      <div class="p-sponsor_silver">
+      <div class="p-sponsor_silver" v-if="sponsors.silver && sponsors.silver.length">
         <div class="title">
           Silver
         </div>
         <div class="row">
-          <div class="list col-sm-4">
+          <div class="list col-sm-4" v-for="sponsor in sponsors.silver" :key="sponsor.name">
             <div class="listItem">
               <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
-              </div>
-              <router-link
-                      to="/jobs"
-                      class="btn">広告・求人ページ<i class="fas fa-chevron-right"></i>
-              </router-link>
-            </div>
-          </div>
-          <div class="list col-sm-4">
-            <div class="listItem">
-              <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
-              </div>
-              <router-link
-                      to="/jobs"
-                      class="btn">広告・求人ページ<i class="fas fa-chevron-right"></i>
-              </router-link>
-            </div>
-          </div>
-          <div class="list col-sm-4">
-            <div class="listItem">
-              <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
-              </div>
-              <router-link
-                      to="/jobs"
-                      class="btn">広告・求人ページ<i class="fas fa-chevron-right"></i>
-              </router-link>
-            </div>
-          </div>
-          <div class="list col-sm-4">
-            <div class="listItem">
-              <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
+                <a :href="sponsor.url" ><div class="thumb" :style="logoStyle(sponsor)" /></a>
               </div>
               <router-link
                       to="/jobs"
@@ -119,57 +60,15 @@
           </div>
         </div>
       </div>
-      <div class="p-sponsor_bronze">
+      <div class="p-sponsor_bronze" v-if="sponsors.bronze && sponsors.bronze.length">
         <div class="title">
           Bronze
         </div>
         <div class="row">
-          <div class="list col-sm-3">
+          <div class="list col-sm-3" v-for="sponsor in sponsors.bronze" :key="sponsor.name">
             <div class="listItem">
               <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
-              </div>
-            </div>
-          </div>
-          <div class="list col-sm-3">
-            <div class="listItem">
-              <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
-              </div>
-            </div>
-          </div>
-          <div class="list col-sm-3">
-            <div class="listItem">
-              <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
-              </div>
-            </div>
-          </div>
-          <div class="list col-sm-3">
-            <div class="listItem">
-              <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
-              </div>
-            </div>
-          </div>
-          <div class="list col-sm-3">
-            <div class="listItem">
-              <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
-              </div>
-            </div>
-          </div>
-          <div class="list col-sm-3">
-            <div class="listItem">
-              <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
-              </div>
-            </div>
-          </div>
-          <div class="list col-sm-3">
-            <div class="listItem">
-              <div class="inner">
-                <a href="#" ><div class="thumb"/></a>
+                <a :href="sponsor.url" ><div class="thumb" :style="logoStyle(sponsor)" /></a>
               </div>
             </div>
           </div>
@@ -182,9 +81,28 @@
 <script>
 
 export default  {
-  components: {
-
-  }
+  props: {
+    sponsors: {
+      type: Object,
+      default: ()=>({}),
+    },
+  },
+  computed: {
+    visible () {
+      // スポンサー情報が、どれか1つ以上のプラン入っていたら表示する
+      return this.sponsors.plutinum && this.sponsors.plutinum.length ||
+        this.sponsors.gold && this.sponsors.gold.length ||
+        this.sponsors.silver && this.sponsors.silver.length ||
+        this.sponsors.bronze && this.sponsors.bronze.length;
+    }
+  },
+  methods:{
+    logoStyle (sponsor){
+      return {
+        backgroundImage: `url('/sponsors/${sponsor.image}')`
+      }
+    }
+  },
 }
 </script>
 

--- a/contents/sponsors.yml
+++ b/contents/sponsors.yml
@@ -1,36 +1,36 @@
 sponsors:
   plutinum:
-    - name: ほげ株式会社
-      url: ""
-      image:
-      introduction:
-      job:
-        title:
-        image:
-        message:
-        buttonTitle:
-        url:
+    # - name: Plutium株式会社
+    #   url: "http://example.com"
+    #   image:
+    #   introduction: 俺は今単にその落第院というのの上をもっななら。何しろ今が関係通りはまあその煩悶うですまでを入れから切らたには記憶なりないですば、いっそにもなっなけれませんた。安危があるたものもとうてい事実をちゃんとでたある。よし嘉納さんでぼんやり詞どう煩悶に応じなら学校その兄弟それかろかをにおいて大記憶たらたたでしょと、この時分はあなたか日数他よりならが、三宅さんのので学校の私にさぞ小評とあるて私教授が小講演に着ようにあたかもご誤解になっないなて、初めてどうしても影響に思いましていなものに当てるなけれた。
+    #   job:
+    #     title:
+    #     image:
+    #     message:
+    #     buttonTitle:
+    #     url:
   gold:
-    - name: ほげ株式会社
-      url: ""
-      image:
-      introduction:
-      job:
-        title:
-        image:
-        message:
-        buttonTitle:
-        url:
+    # - name: gold株式会社
+    #   url: "http://example.com"
+    #   image:
+    #   introduction:
+    #   job:
+    #     title:
+    #     image:
+    #     message:
+    #     buttonTitle:
+    #     url:
   silver:
-    - name: ほげ株式会社
-      url: ""
-      image:
-      job:
-        image:
-        message:
-        buttonTitle:
-        url:
+    # - name: silver株式会社
+    #   url: "http://example.com"
+    #   image:
+    #   job:
+    #     image:
+    #     message:
+    #     buttonTitle:
+    #     url:
   bronze:
-    - name: ほげ株式会社
-      url: ""
-      image:
+    # - name: bronze株式会社
+    #   url: "http://example.com"
+    #   image:

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,6 +5,7 @@
     <sec-wanted></sec-wanted>
     <sec-time-table></sec-time-table>
     <sec-access></sec-access>
+    <sec-sponsor :sponsors="sponsors"></sec-sponsor>
     <sec-thanks :thanks="thanks"></sec-thanks>
   </section>
 </template>
@@ -31,7 +32,10 @@ export default {
   computed:{
     thanks(){
       return this.$store.state.thanks
-    }
+    },
+    sponsors(){
+      return this.$store.state.sponsors
+    },
   },
 }
 </script>


### PR DESCRIPTION
- #31
- `contents/sponsors.yml` を埋めるとスポンサー情報が表示されます
- 各プランに1社以上の情報が有れば、該当プランを表示します
- すべてのプランに情報がなければ、スポンサー情報自体を表示しないです

備考

- 広告・求人ページ `pages/jobs.vue` が作られていない
  - スポンサー情報を入力する前にページを完成させる
  - リンクを一旦外す
